### PR TITLE
bump rust-rss-eapi to 6.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "EUPL-1.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tss-esapi = "5.0"
+tss-esapi = "6.1.1"
 serde = "1.0"
 base64 = "0.12.1"
 


### PR DESCRIPTION
Using the 6.x.y branch as the fix isn't tagged but got merged here https://github.com/parallaxsecond/rust-tss-esapi/pull/261

I've also bumped clevis-pin-tpm2 here: https://github.com/fedora-iot/clevis-pin-tpm2/pull/6

Signed-off-by: Antonio Murdaca <runcom@linux.com>