### PR TITLE
fix: do not crash if PCR value isn't returned

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,12 +1,17 @@
 use std::fmt;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     TPM(tss_esapi::Error),
     NoMatchingPolicy,
     InvalidValue,
     NotImplemented(String),
     IO(std::io::Error),
+    PcrValueNotReturned(
+        tss_esapi::interface_types::algorithm::HashingAlgorithm,
+        Option<tss_esapi::structures::PcrSlot>,
+    ),
 }
 
 impl fmt::Display for Error {
@@ -23,6 +28,11 @@ impl fmt::Display for Error {
                 write!(f, "IO error: ")?;
                 err.fmt(f)
             }
+            Error::PcrValueNotReturned(bank, slot) => write!(
+                f,
+                "PCR value not returned by TPM, bank: {:?}, slot: {:?}",
+                bank, slot
+            ),
         }
     }
 }

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -215,7 +215,7 @@ fn get_pcr_hash_alg_from_name(name: Option<&String>) -> HashingAlgorithm {
             "sha256" => HashingAlgorithm::Sha256,
             "sha384" => HashingAlgorithm::Sha384,
             "sha512" => HashingAlgorithm::Sha512,
-            _ => panic!(format!("Unsupported hash algo: {:?}", name)),
+            _ => panic!("Unsupported hash algo: {:?}", name),
         },
     }
 }


### PR DESCRIPTION
This changes a couple of unwrap() calls to an explicit error to be
returned if a TPM did not return values for specific PCRs.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>