### PR TITLE
Update base64 dependency from 0.12 to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "EUPL-1.2"
 [dependencies]
 tss-esapi = "7.0.0"
 serde = "1.0"
-base64 = "0.12.1"
+base64 = "0.22.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/structures.rs
+++ b/src/structures.rs
@@ -16,6 +16,7 @@ use crate::error::{Error, Result};
 
 use std::convert::{TryFrom, TryInto};
 
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::{Deserialize, Serialize};
 use tss_esapi::{interface_types::algorithm::HashingAlgorithm, structures::SignatureScheme};
 
@@ -23,7 +24,7 @@ fn serialize_as_base64<S>(bytes: &[u8], serializer: S) -> std::result::Result<S:
 where
     S: serde::Serializer,
 {
-    serializer.serialize_str(&base64::encode(bytes))
+    serializer.serialize_str(&STANDARD.encode(bytes))
 }
 
 fn deserialize_as_base64<'de, D>(deserializer: D) -> std::result::Result<Vec<u8>, D::Error>
@@ -31,7 +32,7 @@ where
     D: serde::Deserializer<'de>,
 {
     String::deserialize(deserializer)
-        .and_then(|string| base64::decode(&string).map_err(serde::de::Error::custom))
+        .and_then(|string| STANDARD.decode(&string).map_err(serde::de::Error::custom))
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
I’m not able to run integration tests locally, but I don’t *think* I broke anything. The tests certainly compile, at least.

I’m trying to reduce the number of packages using the `rust-base64_0.12` compat package downstream in Fedora so that it can eventually be retired.

See https://docs.rs/base64/latest/base64/index.html#usage for documentation on using `Engine`s instead of `base64::decode`/`base64::encode`.